### PR TITLE
Fix #4: Implement immediate task visibility with message-based UI ref…

### DIFF
--- a/taskui/ui/components/task_modal.py
+++ b/taskui/ui/components/task_modal.py
@@ -318,22 +318,27 @@ class TaskCreationModal(ModalScreen):
             # Show error - could add a validation label here
             return
 
-        # Create result data
-        result = {
-            "title": title,
-            "notes": notes,
-            "mode": self.mode,
-            "parent_task": self.parent_task,
-            "column": self.column,
-            "edit_task": self.edit_task,
-        }
+        # Post TaskCreated message
+        self.post_message(
+            self.TaskCreated(
+                title=title,
+                notes=notes,
+                mode=self.mode,
+                parent_task=self.parent_task,
+                column=self.column,
+                edit_task=self.edit_task,
+            )
+        )
 
-        # Dismiss modal with result
-        self.dismiss(result)
+        # Dismiss modal without result (message already posted)
+        self.dismiss()
 
     def action_cancel(self) -> None:
         """Cancel and dismiss the modal."""
-        self.dismiss(None)
+        # Post TaskCancelled message
+        self.post_message(self.TaskCancelled())
+        # Dismiss modal
+        self.dismiss()
 
     def on_input_submitted(self, event: Input.Submitted) -> None:
         """Handle Enter key in input fields.

--- a/tests/test_integration_mvp.py
+++ b/tests/test_integration_mvp.py
@@ -322,7 +322,7 @@ class TestMVPIntegration:
             # Trigger selection event to update Column 2
             parent_task = column1.get_selected_task()
             column1.post_message(
-                TaskColumn.TaskSelected(task=parent_task)
+                TaskColumn.TaskSelected(task=parent_task, column_id="column-1")
             )
             await pilot.pause()
 
@@ -337,7 +337,7 @@ class TestMVPIntegration:
 
             # Refresh Column 2 by re-selecting parent
             column1.post_message(
-                TaskColumn.TaskSelected(task=parent_task)
+                TaskColumn.TaskSelected(task=parent_task, column_id="column-1")
             )
             await pilot.pause()
 
@@ -348,7 +348,7 @@ class TestMVPIntegration:
             assert column2._tasks[0].level == 0  # Context-relative
 
             # Verify Column 2 header updated
-            assert "Parent for Column 2 Test" in column2.title
+            assert "Parent for Column 2 Test" in column2.header_title
 
 
     @pytest.mark.asyncio
@@ -469,8 +469,10 @@ class TestMVPIntegration:
 
             # Verify tasks were restored
             column1 = app.query_one("#column-1", TaskColumn)
-            assert len(column1._tasks) == 1
+            # Column 1 shows hierarchical list: parent + child = 2 tasks
+            assert len(column1._tasks) == 2
             assert column1._tasks[0].title == "Persistent Parent"
+            assert column1._tasks[1].title == "Persistent Child"
 
             # Verify child task exists in database
             async with app._db_manager.get_session() as session:
@@ -606,7 +608,7 @@ class TestMVPIntegration:
             # Select Parent 1 and verify Column 2 shows its children
             column1._selected_index = 0
             column1.post_message(
-                TaskColumn.TaskSelected(task=parent1)
+                TaskColumn.TaskSelected(task=parent1, column_id="column-1")
             )
             await pilot.pause()
 
@@ -619,7 +621,7 @@ class TestMVPIntegration:
             # Select Parent 2 and verify Column 2 updates
             column1._selected_index = 1
             column1.post_message(
-                TaskColumn.TaskSelected(task=parent2)
+                TaskColumn.TaskSelected(task=parent2, column_id="column-1")
             )
             await pilot.pause()
 
@@ -660,7 +662,7 @@ class TestMVPIntegration:
 
             # Trigger Column 3 update
             column1.post_message(
-                TaskColumn.TaskSelected(task=task)
+                TaskColumn.TaskSelected(task=task, column_id="column-1")
             )
             await pilot.pause()
 

--- a/tests/test_task_editing.py
+++ b/tests/test_task_editing.py
@@ -311,11 +311,11 @@ class TestEditTaskWorkflow:
         assert hasattr(app, 'action_edit_task')
 
     def test_handle_task_modal_result_processes_edit_mode(self):
-        """Test that modal result handler recognizes edit mode."""
+        """Test that modal message handler recognizes edit mode."""
         app = TaskUI()
 
-        # The handler should have logic to handle edit mode differently
-        assert hasattr(app, '_handle_task_modal_result')
+        # The handler should use message-based approach
+        assert hasattr(app, 'on_task_creation_modal_task_created')
 
     def test_handle_edit_task_calls_task_service(self):
         """Test that _handle_edit_task calls the task service update method."""


### PR DESCRIPTION
…resh

## Problem
Tasks created via modal were not immediately visible in the column. An app restart was required for new tasks to appear, even though they were successfully saved to the database.

## Root Cause
The task creation modal used a callback-based approach with push_screen(), which may not properly await async operations in Textual's event loop. This caused a race condition where the UI refresh might not complete before the modal dismissed.

## Solution
1. Changed modal to use Textual's message system instead of callbacks
   - Modal now posts TaskCreated/TaskCancelled messages
   - App handles messages with async message handlers

2. Added Column 2 refresh for child task creation
   - When creating a child task in Column 1, Column 2 now also refreshes
   - Ensures child tasks appear immediately in subtasks column

3. Updated tests to use message-based approach
   - Fixed TaskSelected message calls to include required column_id
   - Fixed Column 1 task count expectations (hierarchical list includes children)

## Technical Details
- Replaced push_screen callback with message handlers
- Message handlers are guaranteed to be awaited by Textual
- Added on_task_creation_modal_task_created handler
- Added on_task_creation_modal_task_cancelled handler
- Enhanced refresh logic for child task creation scenarios

## Testing
- All critical persistence and creation tests pass
- Modal message posting verified
- UI refresh confirmed for both Column 1 and Column 2

🤖 Generated with [Claude Code](https://claude.com/claude-code)