### PR TITLE
Fix #5: Preserve column focus when clicking tasks with mouse

### DIFF
--- a/taskui/ui/components/column.py
+++ b/taskui/ui/components/column.py
@@ -317,6 +317,9 @@ class TaskColumn(Widget):
             if task.id == message.task_id:
                 self._update_selection(i)
                 break
+        
+        # Ensure column regains focus to maintain keyboard navigation
+        self.focus()
 
     class TaskSelected(Message):
         """Message emitted when a task is selected in the column."""


### PR DESCRIPTION
When a task item is clicked with the mouse, the column now regains focus automatically. This ensures keyboard navigation continues to work after mouse interaction.

Changes:
- Added self.focus() call in TaskColumn.on_task_item_selected()
- Ensures the column regains focus after processing task click
- Maintains active column state and keyboard navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)