### PR TITLE
Fix #6: Enable tab navigation in new task modal

### DIFF
--- a/taskui/ui/keybindings.py
+++ b/taskui/ui/keybindings.py
@@ -17,8 +17,8 @@ from textual.binding import Binding
 NAVIGATION_BINDINGS = [
     Binding("up", "navigate_up", "Navigate Up", show=False),
     Binding("down", "navigate_down", "Navigate Down", show=False),
-    Binding("tab", "navigate_next_column", "Next Column", show=False, priority=True),
-    Binding("shift+tab", "navigate_prev_column", "Previous Column", show=False, priority=True),
+    Binding("tab", "navigate_next_column", "Next Column", show=False),
+    Binding("shift+tab", "navigate_prev_column", "Previous Column", show=False),
 ]
 
 # Task action keybindings


### PR DESCRIPTION
Remove priority=True from tab/shift+tab keybindings to allow Textual's default focus navigation to work in modal dialogs. The priority flag was preventing tab key from moving focus between modal fields (Title → Notes → Buttons).

🤖 Generated with [Claude Code](https://claude.com/claude-code)