### PR TITLE
Fix: Ensure task auto-selection on app launch and column focus

### DIFF
--- a/taskui/ui/app.py
+++ b/taskui/ui/app.py
@@ -177,8 +177,20 @@ class TaskUI(App):
         await self._ensure_default_list()
         await self._restore_app_state()
 
-        # Set initial focus to Column 1
+        # Set initial focus to Column 1 (first column, leftmost)
         self._set_column_focus(COLUMN_1_ID)
+        
+        # Explicitly trigger selection on column 1 after everything is loaded
+        def ensure_column1_selection():
+            try:
+                column1 = self.query_one(f"#{COLUMN_1_ID}", TaskColumn)
+                if column1._tasks and column1._selected_index >= 0:
+                    column1._update_selection(column1._selected_index)
+            except Exception as e:
+                # If it fails, try again after another refresh
+                self.call_after_refresh(ensure_column1_selection)
+        
+        self.call_after_refresh(ensure_column1_selection)
 
     async def _ensure_default_list(self) -> None:
         """Ensure that default lists (Work, Home, Personal) exist in the database.

--- a/taskui/ui/components/column.py
+++ b/taskui/ui/components/column.py
@@ -297,9 +297,29 @@ class TaskColumn(Widget):
         self.selected_task_id = None
 
     def on_focus(self) -> None:
-        """Handle focus event."""
+        """Handle focus event - ensure selection is properly activated."""
         self.focused = True
         self.add_class("focused")
+        
+        # Ensure we have a selection when focusing a column with tasks
+        def ensure_selection():
+            if not self._tasks:
+                return
+            
+            try:
+                if self._selected_index == -1:
+                    # No selection, auto-select first task
+                    self._update_selection(0)
+                elif 0 <= self._selected_index < len(self._tasks):
+                    # Valid selection exists but might not have posted message
+                    # Re-trigger selection to ensure TaskSelected message is posted
+                    self._update_selection(self._selected_index)
+            except Exception:
+                # Widgets not ready yet, try again after refresh
+                self.call_after_refresh(ensure_selection)
+        
+        # Defer to ensure widgets are mounted
+        self.call_after_refresh(ensure_selection)
 
     def on_blur(self) -> None:
         """Handle blur (unfocus) event."""


### PR DESCRIPTION
This addresses a foundational state management issue where columns could be focused without any task selected, leading to inconsistent app state.

Changes:
1. taskui/ui/app.py (on_mount):
   - Add explicit selection trigger after state restore
   - Use retry logic to handle widget mounting timing

2. taskui/ui/components/column.py (on_focus):
   - Auto-select first task when focusing column with no selection
   - Re-trigger selection for existing selections to post TaskSelected message
   - Add retry logic with try/except to handle widget mounting delays

Benefits:
- Column 1 always has a task selected on app launch
- TaskSelected message is properly posted to notify other components
- No "focused column with no selection" edge cases
- Simplifies debugging of issue #13 (column sync problems)

🤖 Generated with [Claude Code](https://claude.com/claude-code)