### PR TITLE
Fix #16: Display completion percentage even at 0%

### DIFF
--- a/taskui/models.py
+++ b/taskui/models.py
@@ -50,6 +50,17 @@ class TaskList(BaseModel):
             return 0.0
         return round((self._completed_count / self._task_count) * 100, 1)
 
+    @computed_field
+    @property
+    def task_count(self) -> int:
+        """
+        Get the total number of tasks in this list.
+
+        Returns:
+            Total number of tasks
+        """
+        return self._task_count
+
     def update_counts(self, task_count: int, completed_count: int) -> None:
         """
         Update the task counts for computed properties.

--- a/taskui/ui/components/list_bar.py
+++ b/taskui/ui/components/list_bar.py
@@ -97,8 +97,8 @@ class ListTab(Widget):
         text.append(self.task_list.name, style=name_style)
 
         # Add completion percentage if there are tasks
-        completion = self.task_list.completion_percentage
-        if completion > 0:
+        if self.task_list.task_count > 0:
+            completion = self.task_list.completion_percentage
             percentage_color = YELLOW if completion < 100 else LEVEL_0_COLOR
             text.append(f" {completion:.0f}%", style=percentage_color)
 


### PR DESCRIPTION
The completion percentage was not visible when it was 0% because the condition checked if `completion > 0` instead of checking if there were tasks to display completion for.

Changes:
- Added `task_count` property to TaskList model to expose the total number of tasks
- Updated ListTab rendering logic to check `task_count > 0` instead of `completion > 0`

This ensures completion percentage is displayed for all lists with tasks, including when completion is at 0%, while still hiding the percentage for empty lists with no tasks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary
<!-- Brief description of changes -->

## Related Issue
Closes #

## Changes
<!-- List the main changes made -->
-
-
-

## Type of Change
<!-- Mark the relevant option(s) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Testing
<!-- Describe the testing done -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All tests passing

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added that prove fix/feature works
- [ ] Dependent changes merged and published

## Screenshots/Evidence
<!-- If applicable, add screenshots or test output -->

## Additional Notes
<!-- Any additional information for reviewers -->
