### PR TITLE
Fix #19: Live update for grandchild completion counter in Column 1

### DIFF
--- a/taskui/ui/components/column.py
+++ b/taskui/ui/components/column.py
@@ -135,6 +135,7 @@ class TaskColumn(Widget):
             all(
                 new.id == old.id and
                 new._child_count == old._child_count and
+                new._completed_child_count == old._completed_child_count and
                 new.is_completed == old.is_completed
                 for new, old in zip(tasks, self._tasks)
             )


### PR DESCRIPTION
## Problem
When completing a grandchild task in Column 2, the completion count in Column 1 (e.g., "3/7") was not updating live—it required an app restart to see the change. The total count worked correctly when adding new tasks, but the completed count did not update dynamically.

## Root Cause
The `tasks_unchanged` check in `taskui/ui/components/column.py` (lines 133-141) was missing `_completed_child_count` in its comparison. When a grandchild task was completed:

1. User completes grandchild task in Column 2
2. `action_toggle_completion()` correctly triggers Column 1 refresh
3. Tasks are fetched from database with updated `_completed_child_count`
4. BUT the `tasks_unchanged` check only compared:
   - `id` (unchanged)
   - `_child_count` (total count, unchanged)
   - `is_completed` (parent itself, unchanged)
5. **Missing**: `_completed_child_count` (the actual value that changed!)
6. Early return skipped re-render, so progress string never updated

## Solution
Added `_completed_child_count` to the `tasks_unchanged` check on line 138:

```python
new._completed_child_count == old._completed_child_count and
```

Now when a grandchild is completed:
- The check detects the `_completed_child_count` change
- Column re-renders with updated progress string
- User sees live update from "2/7" to "3/7"

## Changes
- **File**: `taskui/ui/components/column.py`
- **Lines**: 138 (1 line added)
- **Type**: Bug fix

## Testing
- ✅ All existing tests pass (353 passed)
- ✅ Pre-existing test failures unchanged (8 failed, 5 errors on main)
- ✅ Follows same pattern as existing `_child_count` check
- ✅ Aligns with issue #13 fix for new task count updates

## Closes
Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>