### PR TITLE
Add logging to task completion toggle (Phase 2, Task 2.1)

### DIFF
--- a/taskui/services/task_service.py
+++ b/taskui/services/task_service.py
@@ -762,13 +762,30 @@ class TaskService:
             # Mark as incomplete
             task_orm.is_completed = False
             task_orm.completed_at = None
+            new_state = False
+            logger.info(
+                f"Task completion toggled: task_id={task_id}, "
+                f"new_state=incomplete, timestamp={datetime.utcnow().isoformat()}"
+            )
         else:
             # Mark as completed
             task_orm.is_completed = True
             task_orm.completed_at = datetime.utcnow()
+            new_state = True
+            logger.info(
+                f"Task completion toggled: task_id={task_id}, "
+                f"new_state=completed, timestamp={task_orm.completed_at.isoformat()}"
+            )
 
         # Flush changes to database
-        await self.session.flush()
+        try:
+            await self.session.flush()
+        except Exception as e:
+            logger.error(
+                f"Database update failed for task completion toggle: task_id={task_id}",
+                exc_info=True
+            )
+            raise
 
         # Convert back to Pydantic model
         task = self._orm_to_pydantic(task_orm)

--- a/taskui/ui/app.py
+++ b/taskui/ui/app.py
@@ -665,17 +665,22 @@ class TaskUI(App):
         Toggles the completion status of the currently selected task.
         When completed, the task will display with a strikethrough.
         """
+        logger.debug("Completion toggle key pressed (Space)")
+
         column = self._get_focused_column()
         if not column:
+            logger.debug("No focused column found for completion toggle")
             return
 
         # Get the currently selected task
         selected_task = column.get_selected_task()
         if not selected_task:
             # No task selected, nothing to toggle
+            logger.debug("No task selected for completion toggle")
             return
 
         if not self._db_manager:
+            logger.debug("No database manager available for completion toggle")
             return
 
         try:


### PR DESCRIPTION
## Summary
Implements comprehensive logging for task completion toggle functionality as specified in **Phase 2, Task 2.1** of tasks.md.

The core completion toggle functionality was already fully implemented in Phase 1 (MVP). This PR adds the required logging instrumentation to meet Phase 2 requirements.

## Changes

### `taskui/services/task_service.py`
- **INFO logging**: Log task completion toggled events with task_id, new state (completed/incomplete), and timestamp
- **ERROR logging**: Log database update failures with full exception info (`exc_info=True`)

### `taskui/ui/app.py`
- **DEBUG logging**: Log Space key press event for completion toggle
- **DEBUG logging**: Log edge cases (no focused column, no task selected, no database manager)

## Testing

All existing tests pass:
- ✅ 4/4 tests in `TestTaskServiceToggleCompletion`
- `test_toggle_completion_incomplete_to_complete`
- `test_toggle_completion_complete_to_incomplete`
- `test_toggle_completion_persistence`
- `test_toggle_completion_nonexistent_task`

## Requirements Met

From **Phase 2, Task 2.1** (tasks.md):

**Success Criteria:**
- ✅ Space toggles completion (already implemented in Phase 1)
- ✅ Visual feedback (strikethrough, checkmark, opacity) (already implemented in Phase 1)
- ✅ Completion timestamp saved (already implemented in Phase 1)
- ✅ State persists (already implemented in Phase 1)
- ✅ All completion events logged appropriately (**NEW**)

**Logging Requirements:**
- ✅ INFO: Task completion toggled (task_id, new state, timestamp) (**NEW**)
- ✅ DEBUG: Completion key press event (**NEW**)
- ✅ ERROR: Database update failures with exc_info=True (**NEW**)

## Related
- Closes task 2.1 from Phase 2 in tasks.md
- Follows logging patterns established in Phase 1.1 (Logging Infrastructure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)