### PR TITLE
fix: Refresh Column 2 after task restore to ensure immediate visibility (Issue #28)

### DIFF
--- a/taskui/ui/app.py
+++ b/taskui/ui/app.py
@@ -832,6 +832,16 @@ class TaskUI(App):
             column1 = self.query_one(f"#{COLUMN_1_ID}", TaskColumn)
             await self._refresh_column_tasks(column1)
 
+            # Refresh Column 2 if a parent is selected (in case restored task is a child)
+            selected_task = column1.get_selected_task()
+            if selected_task:
+                logger.debug(
+                    f"Refreshing Column 2 after task restore in case {restored_task.id} "
+                    f"is a child of selected parent {selected_task.id}"
+                )
+                column2 = self.query_one(f"#{COLUMN_2_ID}", TaskColumn)
+                await self._refresh_column_tasks(column2)
+
             # Refresh the list bar to update completion percentage
             if self._current_list_id:
                 await self._refresh_list_bar_for_list(self._current_list_id)


### PR DESCRIPTION
## Summary
Fixes #28 - When a task is restored from the archive, it is now immediately visible in the UI.

## Problem
When a task was restored from the archive, only Column 1 was refreshed. If the restored task was a child of a currently selected parent task, it wouldn't appear in Column 2 until manual refresh or app restart.

## Solution
Added Column 2 refresh logic to the `on_archive_modal_task_restored` handler in `app.py`. The fix now:
1. Refreshes Column 1 (to show top-level restored tasks)
2. Refreshes Column 2 if a parent is selected (to show restored child tasks)
3. Refreshes the list bar (to update completion percentages)

This mirrors the pattern used in other task operations like archiving and completion toggling.

## Changes
- `taskui/ui/app.py:835-843` - Added Column 2 refresh logic after task restore

## Testing
- ✅ All 15 archive modal tests pass
- ✅ All 17 archive service tests pass
- ✅ No regressions in existing functionality

## Manual Testing Steps
1. Create a parent task with children
2. Archive a child task
3. Open archive modal (Ctrl+Shift+A)
4. Restore the child task
5. Close archive modal
6. ✅ Child task should immediately appear in Column 2

## Related
- Issue #29 - Refactoring opportunity to standardize refresh logic across the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)