### PR TITLE
fix: Make keybinds case-insensitive (Issue #26)

### DIFF
--- a/taskui/ui/keybindings.py
+++ b/taskui/ui/keybindings.py
@@ -23,12 +23,12 @@ NAVIGATION_BINDINGS = [
 
 # Task action keybindings
 TASK_ACTION_BINDINGS = [
-    Binding("n", "new_sibling_task", "New Sibling Task", show=True),
-    Binding("c", "new_child_task", "New Child Task", show=True),
-    Binding("e", "edit_task", "Edit Task", show=True),
+    Binding("n,N", "new_sibling_task", "New Sibling Task", show=True),
+    Binding("c,C", "new_child_task", "New Child Task", show=True),
+    Binding("e,E", "edit_task", "Edit Task", show=True),
     Binding("space", "toggle_completion", "Toggle Complete", show=True),
-    Binding("a", "archive_task", "Archive Task", show=True),
-    Binding("v", "view_archives", "View Archives", show=True),
+    Binding("a,A", "archive_task", "Archive Task", show=True),
+    Binding("v,V", "view_archives", "View Archives", show=True),
     Binding("delete,backspace", "delete_task", "Delete Task", show=True),
 ]
 
@@ -41,12 +41,12 @@ LIST_BINDINGS = [
 
 # Printing keybindings
 PRINT_BINDINGS = [
-    Binding("p", "print_column", "Print Column", show=True),
+    Binding("p,P", "print_column", "Print Column", show=True),
 ]
 
 # Application control keybindings
 APP_CONTROL_BINDINGS = [
-    Binding("q", "quit", "Quit", priority=True, show=True),
+    Binding("q,Q", "quit", "Quit", priority=True, show=True),
     Binding("question_mark", "help", "Help", show=True),
     Binding("escape", "cancel", "Cancel", show=False),
 ]

--- a/tests/test_keyboard_navigation.py
+++ b/tests/test_keyboard_navigation.py
@@ -48,6 +48,35 @@ class TestKeybindings:
         """Test that column order is correct."""
         assert COLUMN_ORDER == [COLUMN_1_ID, COLUMN_2_ID, COLUMN_3_ID]
 
+    def test_letter_keybindings_case_insensitive(self):
+        """Test that letter keybindings work with both uppercase and lowercase (Issue #26)."""
+        bindings = get_all_bindings()
+        binding_dict = {b.key: b.action for b in bindings}
+
+        # Test task action bindings accept both cases
+        assert "n,N" in binding_dict
+        assert binding_dict["n,N"] == "new_sibling_task"
+
+        assert "c,C" in binding_dict
+        assert binding_dict["c,C"] == "new_child_task"
+
+        assert "e,E" in binding_dict
+        assert binding_dict["e,E"] == "edit_task"
+
+        assert "a,A" in binding_dict
+        assert binding_dict["a,A"] == "archive_task"
+
+        assert "v,V" in binding_dict
+        assert binding_dict["v,V"] == "view_archives"
+
+        # Test print binding
+        assert "p,P" in binding_dict
+        assert binding_dict["p,P"] == "print_column"
+
+        # Test quit binding
+        assert "q,Q" in binding_dict
+        assert binding_dict["q,Q"] == "quit"
+
     def test_get_next_column_cycles(self):
         """Test that get_next_column cycles through columns."""
         assert get_next_column(COLUMN_1_ID) == COLUMN_2_ID


### PR DESCRIPTION
## Summary
Fixes keybinds being case-sensitive, which made the app appear unresponsive when caps lock was enabled.

## Changes
- Updated all letter keybindings to accept both uppercase and lowercase variants (e.g., `n,N`)
- Added comprehensive test to verify case-insensitive behavior
- Ensures consistent user experience regardless of caps lock state

## Testing
- ✅ New test `test_letter_keybindings_case_insensitive` passes
- ✅ All existing keybinding tests pass
- ✅ App starts and runs without errors

## Affected Keybindings
- `n,N` → New Sibling Task
- `c,C` → New Child Task
- `e,E` → Edit Task
- `a,A` → Archive Task
- `v,V` → View Archives
- `p,P` → Print Column
- `q,Q` → Quit

Closes #26

🤖 Generated with [Claude Code](https://claude.com/claude-code)