### PR TITLE
refactor: Remove deprecated database helper methods

### DIFF
--- a/taskui/database.py
+++ b/taskui/database.py
@@ -5,7 +5,6 @@ Provides SQLAlchemy ORM models, async engine/session management, and database
 initialization for SQLite persistence.
 """
 
-import warnings
 from contextlib import asynccontextmanager
 from datetime import datetime
 from pathlib import Path
@@ -182,60 +181,6 @@ class DatabaseManager:
                 logger.error(f"Database session error, rolling back: {e}", exc_info=True)
                 await session.rollback()
                 raise
-
-    async def get_task_list_by_id(self, session: AsyncSession, list_id: UUID) -> Optional[TaskListORM]:
-        """
-        Retrieve a task list by ID.
-
-        .. deprecated:: 1.0
-            Use ListService.get_list_by_id() instead.
-            This method will be removed in version 2.0.
-
-        Args:
-            session: Active database session
-            list_id: UUID of the task list
-
-        Returns:
-            TaskListORM instance or None if not found
-        """
-        warnings.warn(
-            "DatabaseManager.get_task_list_by_id() is deprecated. "
-            "Use ListService.get_list_by_id() instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-
-        result = await session.execute(
-            select(TaskListORM).where(TaskListORM.id == str(list_id))
-        )
-        return result.scalar_one_or_none()
-
-    async def get_task_by_id(self, session: AsyncSession, task_id: UUID) -> Optional[TaskORM]:
-        """
-        Retrieve a task by ID.
-
-        .. deprecated:: 1.0
-            Use TaskService.get_task_by_id() instead.
-            This method will be removed in version 2.0.
-
-        Args:
-            session: Active database session
-            task_id: UUID of the task
-
-        Returns:
-            TaskORM instance or None if not found
-        """
-        warnings.warn(
-            "DatabaseManager.get_task_by_id() is deprecated. "
-            "Use TaskService.get_task_by_id() instead.",
-            DeprecationWarning,
-            stacklevel=2
-        )
-
-        result = await session.execute(
-            select(TaskORM).where(TaskORM.id == str(task_id))
-        )
-        return result.scalar_one_or_none()
 
 
 # Global database manager instance

--- a/tests/test_database.py
+++ b/tests/test_database.py
@@ -372,40 +372,6 @@ class TestDatabaseHelperFunctions:
     """Tests for helper functions."""
 
     @pytest.mark.asyncio
-    async def test_get_task_list_by_id(self, db_manager, sample_task_list, sample_list_id):
-        """Test retrieving task list by ID."""
-        async with db_manager.get_session() as session:
-            result = await db_manager.get_task_list_by_id(session, sample_list_id)
-
-            assert result is not None
-            assert result.id == str(sample_list_id)
-            assert result.name == "Work"
-
-    @pytest.mark.asyncio
-    async def test_get_task_list_by_id_not_found(self, db_manager):
-        """Test that get_task_list_by_id returns None for non-existent ID."""
-        async with db_manager.get_session() as session:
-            result = await db_manager.get_task_list_by_id(session, uuid4())
-            assert result is None
-
-    @pytest.mark.asyncio
-    async def test_get_task_by_id(self, db_manager, sample_task_list, sample_task, sample_task_id):
-        """Test retrieving task by ID."""
-        async with db_manager.get_session() as session:
-            result = await db_manager.get_task_by_id(session, sample_task_id)
-
-            assert result is not None
-            assert result.id == str(sample_task_id)
-            assert result.title == "Complete project documentation"
-
-    @pytest.mark.asyncio
-    async def test_get_task_by_id_not_found(self, db_manager):
-        """Test that get_task_by_id returns None for non-existent ID."""
-        async with db_manager.get_session() as session:
-            result = await db_manager.get_task_by_id(session, uuid4())
-            assert result is None
-
-    @pytest.mark.asyncio
     async def test_init_database_helper(self):
         """Test init_database convenience function."""
         db_manager = await init_database("sqlite+aiosqlite:///:memory:")


### PR DESCRIPTION
Remove deprecated methods after merge to main:
- DatabaseManager.get_task_list_by_id() - use ListService.get_list_by_id()
- DatabaseManager.get_task_by_id() - use TaskService.get_task_by_id()

Also removed:
- 4 tests that tested the deprecated methods
- Unused 'warnings' import from database.py

All functionality is available through the service layer. All database and service tests pass (109/109).

## Summary
<!-- Brief description of changes -->

## Related Issue
Closes #

## Changes
<!-- List the main changes made -->
-
-
-

## Type of Change
<!-- Mark the relevant option(s) -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition or update

## Testing
<!-- Describe the testing done -->
- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] Manual testing completed
- [ ] All tests passing

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if needed)
- [ ] No new warnings generated
- [ ] Tests added that prove fix/feature works
- [ ] Dependent changes merged and published

## Screenshots/Evidence
<!-- If applicable, add screenshots or test output -->

## Additional Notes
<!-- Any additional information for reviewers -->
