### PR TITLE
Add USB printer support as configurable option

### DIFF
--- a/docs/config.ini.example
+++ b/docs/config.ini.example
@@ -2,10 +2,19 @@
 # Copy this file to ~/.taskui/config.ini and customize as needed
 
 [printer]
-# Thermal printer network configuration
+# Printer connection type: 'network' or 'usb'
+connection_type = network
+
+# Network printer configuration (used when connection_type = network)
 host = 192.168.50.99
 port = 9100
 timeout = 60
+
+# USB printer configuration (used when connection_type = usb)
+# Common device paths:
+#   Linux: /dev/usb/lp0, /dev/usb/lp1
+#   macOS: /dev/cu.usbserial, /dev/tty.usbserial
+device_path = /dev/usb/lp0
 
 # Print format options (minimal is recommended)
 detail_level = minimal

--- a/taskui/config.py
+++ b/taskui/config.py
@@ -49,15 +49,19 @@ class Config:
         Get printer configuration with environment overrides.
 
         Environment variables take precedence over config file:
+        - TASKUI_PRINTER_CONNECTION_TYPE
         - TASKUI_PRINTER_HOST
         - TASKUI_PRINTER_PORT
         - TASKUI_PRINTER_TIMEOUT
         - TASKUI_PRINTER_DETAIL_LEVEL
+        - TASKUI_PRINTER_DEVICE_PATH
 
         Returns:
             Dictionary with printer configuration
         """
         config = {
+            'connection_type': os.getenv('TASKUI_PRINTER_CONNECTION_TYPE') or
+                              self._config.get('printer', 'connection_type', fallback='network'),
             'host': os.getenv('TASKUI_PRINTER_HOST') or
                    self._config.get('printer', 'host', fallback='192.168.50.99'),
             'port': int(os.getenv('TASKUI_PRINTER_PORT') or
@@ -66,9 +70,13 @@ class Config:
                           self._config.get('printer', 'timeout', fallback='60')),
             'detail_level': os.getenv('TASKUI_PRINTER_DETAIL_LEVEL') or
                            self._config.get('printer', 'detail_level', fallback='minimal'),
+            'device_path': os.getenv('TASKUI_PRINTER_DEVICE_PATH') or
+                          self._config.get('printer', 'device_path', fallback='/dev/usb/lp0'),
         }
 
-        logger.debug(f"Printer config: host={config['host']}, port={config['port']}, "
+        logger.debug(f"Printer config: connection_type={config['connection_type']}, "
+                    f"host={config['host']}, port={config['port']}, "
+                    f"device_path={config['device_path']}, "
                     f"detail_level={config['detail_level']}")
 
         return config


### PR DESCRIPTION
This commit adds USB printing capability alongside the existing network printing support. Users can now configure their printer connection type in the config file or via environment variables.

Changes:
- Added connection_type (network/usb) and device_path configuration options
- Updated PrinterConfig class to support USB parameters with validation
- Modified PrinterService.connect() to support both Network and USB printers
- Updated config.ini.example with USB configuration documentation
- Added comprehensive tests for USB configuration and connection
- All existing tests pass, maintaining backward compatibility

Configuration example:
  [printer] connection_type = usb device_path = /dev/usb/lp0

The default remains network printing to maintain backward compatibility.